### PR TITLE
Show image fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ a {
       <td>Maximum upload image</td>
     </tr>
     <tr>
-      <td>showImageList</td>
+      <td>showImageReorder</td>
       <td>Boolean</td>
       <td>true</td>
       <td>Show bottom image row, add image icon will be moved inside main block</td>

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ a {
       <td>Maximum upload image</td>
     </tr>
     <tr>
+      <td>showImageList</td>
+      <td>Boolean</td>
+      <td>true</td>
+      <td>Show bottom image row, add image icon will be moved inside main block</td>
+    </tr>
+    <tr>
       <td>showEdit</td>
       <td>Boolean</td>
       <td>true</td>

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -309,22 +309,36 @@ export default {
   },
   computed: {
     imagePreview() {
+      console.log('🖼️ Computing imagePreview:')
+      console.log('  - this.images:', this.images)
+      console.log('  - this.images.length:', this.images?.length)
+
       // Add safety checks for undefined elements
       if (!this.images || !this.images.length) {
+        console.log('  - No images available for preview')
         return ''
       }
 
       // Find highlighted image, but filter out undefined elements first
       const validImages = this.images.filter(img => img && img.path)
+      console.log('  - Valid images:', validImages.length)
+
       if (!validImages.length) {
+        console.log('  - No valid images with path')
         return ''
       }
 
       let index = findIndex(validImages, { highlight: 1 })
+      console.log('  - Highlighted image index:', index)
+
       if (index > -1 && validImages[index] && validImages[index].path) {
+        const preview = validImages[index].path.substring(0, 50) + '...'
+        console.log('  - Using highlighted image:', preview)
         return validImages[index].path
       } else {
         // Fallback to first valid image
+        const preview = validImages[0].path.substring(0, 50) + '...'
+        console.log('  - Using first valid image:', preview)
         return validImages[0] && validImages[0].path ? validImages[0].path : ''
       }
     },
@@ -340,10 +354,18 @@ export default {
 
     // Add computed property for valid images
     validImages() {
+      console.log('✅ Computing validImages:')
+      console.log('  - this.images:', this.images)
+
       if (!this.images || !Array.isArray(this.images)) {
+        console.log('  - No images or not array, returning empty')
         return []
       }
-      return this.images.filter(img => img && (img.path || img.name))
+
+      const valid = this.images.filter(img => img && (img.path || img.name))
+      console.log('  - Valid images count:', valid.length)
+      console.log('  - Valid images:', valid)
+      return valid
     }
   },
   methods: {
@@ -540,7 +562,7 @@ export default {
       }
 
       if (currentIndex < this.validImages.length - 1 && direction === 'down') {
-        // Move right (swap with next)  
+        // Move right (swap with next)
         this.images.splice(currentIndex + 1, 0, this.images.splice(currentIndex, 1)[0])
         newIndex = currentIndex + 1
       }
@@ -567,16 +589,34 @@ export default {
   watch: {
     dataImages: {
       handler: function (newVal) {
+        console.log('🔍 dataImages watcher triggered:')
+        console.log('  - newVal:', newVal)
+        console.log('  - newVal length:', newVal?.length)
+        console.log('  - newVal is array:', Array.isArray(newVal))
+
         // Add safety check for async data loading
         if (newVal && Array.isArray(newVal)) {
           this.images = cloneDeep(newVal)
+          console.log('  - images set to:', this.images)
+          console.log('  - images length:', this.images.length)
         } else {
           this.images = []
+          console.log('  - images reset to empty array')
         }
       },
       deep: true,
       immediate: true
     },
+
+    images: {
+      handler: function (newVal) {
+        console.log('🖼️ Internal images array changed:')
+        console.log('  - length:', newVal?.length)
+        console.log('  - first image:', newVal?.[0])
+      },
+      deep: true
+    },
+
     currentIndex: {
       handler: function (newVal) {
         if (newVal >= 0 && newVal < this.images.length) {
@@ -603,8 +643,16 @@ export default {
     })
   },
   created() {
+    console.log('🚀 Component created:')
+    console.log('  - dataImages prop:', this.dataImages)
+    console.log('  - dataImages length:', this.dataImages?.length)
+
     this.images = []
-    this.images = cloneDeep(this.dataImages)
+    if (this.dataImages && Array.isArray(this.dataImages)) {
+      this.images = cloneDeep(this.dataImages)
+      console.log('  - Initial images set:', this.images)
+      console.log('  - Initial images length:', this.images.length)
+    }
   },
 }
 </script>
@@ -1039,6 +1087,7 @@ export default {
   border-color: #6c757d;
 }
 
+/* Add placeholder style for loading images */
 .image-placeholder {
   display: flex;
   align-items: center;

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -259,6 +259,10 @@ export default {
     showImageList: {
       type: Boolean,
       default: true
+    },
+    currentIndex: {
+      type: Number,
+      default: 0
     }
   },
   data() {
@@ -451,6 +455,14 @@ export default {
         this.images = cloneDeep(newVal)
       },
       deep: true
+    },
+    currentIndex: {
+      handler: function (newVal) {
+        if (newVal >= 0 && newVal < this.images.length) {
+          this.changeHighlight(newVal)
+        }
+      },
+      immediate: true
     }
   },
   mounted() {

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -309,36 +309,22 @@ export default {
   },
   computed: {
     imagePreview() {
-      console.log('🖼️ Computing imagePreview:')
-      console.log('  - this.images:', this.images)
-      console.log('  - this.images.length:', this.images?.length)
-
       // Add safety checks for undefined elements
       if (!this.images || !this.images.length) {
-        console.log('  - No images available for preview')
         return ''
       }
 
       // Find highlighted image, but filter out undefined elements first
       const validImages = this.images.filter(img => img && img.path)
-      console.log('  - Valid images:', validImages.length)
-
       if (!validImages.length) {
-        console.log('  - No valid images with path')
         return ''
       }
 
       let index = findIndex(validImages, { highlight: 1 })
-      console.log('  - Highlighted image index:', index)
-
       if (index > -1 && validImages[index] && validImages[index].path) {
-        const preview = validImages[index].path.substring(0, 50) + '...'
-        console.log('  - Using highlighted image:', preview)
         return validImages[index].path
       } else {
         // Fallback to first valid image
-        const preview = validImages[0].path.substring(0, 50) + '...'
-        console.log('  - Using first valid image:', preview)
         return validImages[0] && validImages[0].path ? validImages[0].path : ''
       }
     },
@@ -354,18 +340,10 @@ export default {
 
     // Add computed property for valid images
     validImages() {
-      console.log('✅ Computing validImages:')
-      console.log('  - this.images:', this.images)
-
       if (!this.images || !Array.isArray(this.images)) {
-        console.log('  - No images or not array, returning empty')
         return []
       }
-
-      const valid = this.images.filter(img => img && (img.path || img.name))
-      console.log('  - Valid images count:', valid.length)
-      console.log('  - Valid images:', valid)
-      return valid
+      return this.images.filter(img => img && (img.path || img.name))
     }
   },
   methods: {
@@ -562,7 +540,7 @@ export default {
       }
 
       if (currentIndex < this.validImages.length - 1 && direction === 'down') {
-        // Move right (swap with next)
+        // Move right (swap with next)  
         this.images.splice(currentIndex + 1, 0, this.images.splice(currentIndex, 1)[0])
         newIndex = currentIndex + 1
       }
@@ -589,34 +567,16 @@ export default {
   watch: {
     dataImages: {
       handler: function (newVal) {
-        console.log('🔍 dataImages watcher triggered:')
-        console.log('  - newVal:', newVal)
-        console.log('  - newVal length:', newVal?.length)
-        console.log('  - newVal is array:', Array.isArray(newVal))
-
         // Add safety check for async data loading
         if (newVal && Array.isArray(newVal)) {
           this.images = cloneDeep(newVal)
-          console.log('  - images set to:', this.images)
-          console.log('  - images length:', this.images.length)
         } else {
           this.images = []
-          console.log('  - images reset to empty array')
         }
       },
       deep: true,
       immediate: true
     },
-
-    images: {
-      handler: function (newVal) {
-        console.log('🖼️ Internal images array changed:')
-        console.log('  - length:', newVal?.length)
-        console.log('  - first image:', newVal?.[0])
-      },
-      deep: true
-    },
-
     currentIndex: {
       handler: function (newVal) {
         if (newVal >= 0 && newVal < this.images.length) {
@@ -643,16 +603,8 @@ export default {
     })
   },
   created() {
-    console.log('🚀 Component created:')
-    console.log('  - dataImages prop:', this.dataImages)
-    console.log('  - dataImages length:', this.dataImages?.length)
-
     this.images = []
-    if (this.dataImages && Array.isArray(this.dataImages)) {
-      this.images = cloneDeep(this.dataImages)
-      console.log('  - Initial images set:', this.images)
-      console.log('  - Initial images length:', this.images.length)
-    }
+    this.images = cloneDeep(this.dataImages)
   },
 }
 </script>
@@ -1087,7 +1039,6 @@ export default {
   border-color: #6c757d;
 }
 
-/* Add placeholder style for loading images */
 .image-placeholder {
   display: flex;
   align-items: center;

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -307,17 +307,35 @@ export default {
     VueImageLightboxCarousel
   },
   computed: {
-    imagePreview() {
-      let index = findIndex(this.images, { highlight: 1 })
-      if (index > -1) {
-        return this.images[index].path
-      } else {
-        return this.images.length ? this.images[0].path : ''
-      }
-    },
-    imageDefault() {
-      if (this.images[this.currentIndexImage]) {
-        return this.images[this.currentIndexImage].default
+    computed: {
+      imagePreview() {
+        // Add safety checks for undefined elements
+        if (!this.images || !this.images.length) {
+          return ''
+        }
+
+        // Find highlighted image, but filter out undefined elements first
+        const validImages = this.images.filter(img => img && img.path)
+        if (!validImages.length) {
+          return ''
+        }
+
+        let index = findIndex(validImages, { highlight: 1 })
+        if (index > -1 && validImages[index] && validImages[index].path) {
+          return validImages[index].path
+        } else {
+          // Fallback to first valid image
+          return validImages[0] && validImages[0].path ? validImages[0].path : ''
+        }
+      },
+
+      imageDefault() {
+        if (!this.images || !this.images.length) {
+          return false
+        }
+
+        const currentImage = this.images[this.currentIndexImage]
+        return currentImage && currentImage.default ? currentImage.default : false
       }
     }
   },

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -307,36 +307,34 @@ export default {
     VueImageLightboxCarousel
   },
   computed: {
-    computed: {
-      imagePreview() {
-        // Add safety checks for undefined elements
-        if (!this.images || !this.images.length) {
-          return ''
-        }
-
-        // Find highlighted image, but filter out undefined elements first
-        const validImages = this.images.filter(img => img && img.path)
-        if (!validImages.length) {
-          return ''
-        }
-
-        let index = findIndex(validImages, { highlight: 1 })
-        if (index > -1 && validImages[index] && validImages[index].path) {
-          return validImages[index].path
-        } else {
-          // Fallback to first valid image
-          return validImages[0] && validImages[0].path ? validImages[0].path : ''
-        }
-      },
-
-      imageDefault() {
-        if (!this.images || !this.images.length) {
-          return false
-        }
-
-        const currentImage = this.images[this.currentIndexImage]
-        return currentImage && currentImage.default ? currentImage.default : false
+    imagePreview() {
+      // Add safety checks for undefined elements
+      if (!this.images || !this.images.length) {
+        return ''
       }
+
+      // Find highlighted image, but filter out undefined elements first
+      const validImages = this.images.filter(img => img && img.path)
+      if (!validImages.length) {
+        return ''
+      }
+
+      let index = findIndex(validImages, { highlight: 1 })
+      if (index > -1 && validImages[index] && validImages[index].path) {
+        return validImages[index].path
+      } else {
+        // Fallback to first valid image
+        return validImages[0] && validImages[0].path ? validImages[0].path : ''
+      }
+    },
+
+    imageDefault() {
+      if (!this.images || !this.images.length) {
+        return false
+      }
+
+      const currentImage = this.images[this.currentIndexImage]
+      return currentImage && currentImage.default ? currentImage.default : false
     }
   },
   methods: {

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -1,200 +1,139 @@
 <template>
-  <div
-    style="outline: none;"
-    @drag="preventEvent"
-    @dragstart="preventEvent"
-    @dragend="preventEvent"
-    @dragover="preventEvent"
-    @dragenter="preventEvent"
-    @dragleave="preventEvent"
-    @drop="preventEvent"
-  >
-    <div
-      class="image-container position-relative text-center"
-      v-if="!images.length"
-    >
-      <div
-        class="drag-upload-cover position-absolute"
-        v-if="isDragover"
-        @drop="onDrop"
-      >
+  <div style="outline: none;" @drag="preventEvent" @dragstart="preventEvent" @dragend="preventEvent"
+    @dragover="preventEvent" @dragenter="preventEvent" @dragleave="preventEvent" @drop="preventEvent">
+    <div class="image-container position-relative text-center" v-if="!images.length">
+      <div class="drag-upload-cover position-absolute" v-if="isDragover" @drop="onDrop">
         <div class="centered full-width text-center text-primary">
-          <svg
-            class="icon-drag-drop"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-          >
-            <path d="M444.5 15C407.7 15 378 44.8 378 81.5s29.8 66.5 66.5 66.5S511 118.2 511 81.5 481.2 15 444.5 15zm29.4 72.4h-23.5l.1 25.9c0 3.2-2.6 5.8-5.8 5.9-3.2 0-5.8-2.6-5.8-5.8l-.1-26h-23.6c-3.2 0-5.8-2.6-5.8-5.8s2.6-5.8 5.8-5.8h23.5l-.1-25.9c0-3.2 2.6-5.8 5.8-5.9 3.2 0 5.8 2.6 5.8 5.8l.1 26h23.6c3.3 0 5.8 2.6 5.8 5.8s-2.6 5.8-5.8 5.8zM199.3 191.3c21.5 0 38.9 17.6 38.9 39.3s-17.4 39.3-38.9 39.3-38.9-17.6-38.9-39.3c0-21.7 17.5-39.3 38.9-39.3zm185.4 201.3H86.3c-6.5 0-11.9-5.3-11.9-11.9v-32.4c0-2.5.7-4.8 2.1-6.9l41.3-58.4c3.7-5.2 10.8-6.5 16.1-3.1l56.4 36.8c4.5 3 10.3 2.5 14.4-1L313 220.1c5.1-4.5 13.1-3.8 17.2 1.7l61.5 79.7c1.6 2 2.5 4.6 2.5 7.2v74.4c0 5.2-4.3 9.5-9.5 9.5zm7.9 117.6h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0H98.4v-12h58.8v12h.1zm-78.5 0H57.7c-14.3 0-27.9-5.4-38.3-15.3l8.3-8.7c8.2 7.8 18.8 12 30.1 12h21.1l-.1 12zm333.6-.1l-.3-12c17.8-.4 33.4-11.5 39.8-28.2l11.2 4.3c-8.1 21.3-28 35.4-50.7 35.9zM6.8 477c-3.2-7.1-4.7-14.7-4.7-22.5v-38.2h12v38.2c0 6.1 1.3 12.1 3.7 17.6l-11 4.9zm459.9-24.1h-12v-58.8h12v58.8zM14.1 396.7h-12v-58.8h12v58.8zm452.6-22.3h-12v-58.8h12v58.8zM14.1 318.3h-12v-58.8h12v58.8zM466.7 296h-12v-58.8h12V296zM14.1 239.8h-12V181h12v58.8zm452.6-22.2h-12v-58.8h12v58.8zM14.1 161.4h-12v-58.8h12v58.8zm2.4-76.1L5.3 81.2C13 59.9 33.4 45.5 56.1 45.5h.2v12h-.2c-17.7 0-33.6 11.2-39.6 27.8zm353.6-27.8h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0H75.9v-12h58.8v12z"></path>
+          <svg class="icon-drag-drop" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+            <path
+              d="M444.5 15C407.7 15 378 44.8 378 81.5s29.8 66.5 66.5 66.5S511 118.2 511 81.5 481.2 15 444.5 15zm29.4 72.4h-23.5l.1 25.9c0 3.2-2.6 5.8-5.8 5.9-3.2 0-5.8-2.6-5.8-5.8l-.1-26h-23.6c-3.2 0-5.8-2.6-5.8-5.8s2.6-5.8 5.8-5.8h23.5l-.1-25.9c0-3.2 2.6-5.8 5.8-5.9 3.2 0 5.8 2.6 5.8 5.8l.1 26h23.6c3.3 0 5.8 2.6 5.8 5.8s-2.6 5.8-5.8 5.8zM199.3 191.3c21.5 0 38.9 17.6 38.9 39.3s-17.4 39.3-38.9 39.3-38.9-17.6-38.9-39.3c0-21.7 17.5-39.3 38.9-39.3zm185.4 201.3H86.3c-6.5 0-11.9-5.3-11.9-11.9v-32.4c0-2.5.7-4.8 2.1-6.9l41.3-58.4c3.7-5.2 10.8-6.5 16.1-3.1l56.4 36.8c4.5 3 10.3 2.5 14.4-1L313 220.1c5.1-4.5 13.1-3.8 17.2 1.7l61.5 79.7c1.6 2 2.5 4.6 2.5 7.2v74.4c0 5.2-4.3 9.5-9.5 9.5zm7.9 117.6h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0H98.4v-12h58.8v12h.1zm-78.5 0H57.7c-14.3 0-27.9-5.4-38.3-15.3l8.3-8.7c8.2 7.8 18.8 12 30.1 12h21.1l-.1 12zm333.6-.1l-.3-12c17.8-.4 33.4-11.5 39.8-28.2l11.2 4.3c-8.1 21.3-28 35.4-50.7 35.9zM6.8 477c-3.2-7.1-4.7-14.7-4.7-22.5v-38.2h12v38.2c0 6.1 1.3 12.1 3.7 17.6l-11 4.9zm459.9-24.1h-12v-58.8h12v58.8zM14.1 396.7h-12v-58.8h12v58.8zm452.6-22.3h-12v-58.8h12v58.8zM14.1 318.3h-12v-58.8h12v58.8zM466.7 296h-12v-58.8h12V296zM14.1 239.8h-12V181h12v58.8zm452.6-22.2h-12v-58.8h12v58.8zM14.1 161.4h-12v-58.8h12v58.8zm2.4-76.1L5.3 81.2C13 59.9 33.4 45.5 56.1 45.5h.2v12h-.2c-17.7 0-33.6 11.2-39.6 27.8zm353.6-27.8h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0H75.9v-12h58.8v12z">
+            </path>
           </svg>
-          <h4 class="drop-text-here"><b>{{dropText}}</b></h4>
+          <h4 class="drop-text-here"><b>{{ dropText }}</b></h4>
         </div>
       </div>
-      <div
-        v-else
+      <div v-else
         class="image-center position-absolute display-flex flex-column justify-content-center align-items-center"
-        @dragover.prevent="onDragover"
-      >
+        @dragover.prevent="onDragover">
         <div>
-          <svg
-            class="image-icon-drag"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-          >
-            <path d="M383.6 229l-.5 1.5.7 1.7c-.2-1.1-.2-2.2-.2-3.2zm-119.7-5.4l-.3 1.4.6 1.3c-.2-.8-.3-1.8-.3-2.7zm62.4 3.8l-.2 1 .5 1.1-.3-2.1z"></path>
-            <path d="M483 326.2l-43.5-100.5c-3.6-8.4-10.3-14.9-18.7-18.4-8.5-3.6-17.8-3.5-26.1.1L391 209c-3.3 1.4-6.1 3.6-8.4 6.3-3.6-8.2-10.2-14.6-18.6-18-8.5-3.4-17.7-3.3-26.1.3-6.1 2.7-10.9 6.8-13.9 12-3.7-8-10.2-14.3-18.4-17.6-8.5-3.4-17.8-3.3-26.1.3l-3.7 1.6c-6.3 2.7-11.2 7.1-14.3 12.4l-20.3-46.9c-4.2-9.8-10.7-16.8-18.7-20.2-8.1-3.5-17.2-3.2-26.5.8l-3.7 1.6c-8 3.5-13.3 9.3-15.5 16.9-2.1 7.3-1 16.2 3.1 25.6l83.4 188.2-64.7-39.8c-11.2-6.8-25.7-4.7-34.4 5.1-11.3 12.5-10.3 31.9 2 43.3l55.8 51.5 50.8 43.4c17.6 16.7 38.2 28.1 59.6 32.9 7.7 1.7 15.5 2.5 23.2 2.5 14.9 0 29.7-3.1 44.2-9.4l27.9-12.1c31.2-13.5 52.8-37.1 62.6-68.4 9.2-29.2 6.6-63-7.3-95.1zM383.6 229c0 1 .1 2.1.2 3.1l-.7-1.7.5-1.4zM281.7 466.6c-.2-.2-.5-.5-.7-.6l-50.4-43.1-55.6-51.5c-7.3-6.7-7.9-18.2-1.2-25.6 4.7-5.3 12.5-6.4 18.5-2.6l65.6 40.2c4.7 2.9 10.4 2.4 14.5-1.3 4.1-3.6 5.3-9.2 3.2-14.2l-83.7-189c-3.2-7.4-3.9-13.4-2.1-18.1 1.7-4.3 5.2-6.5 7.9-7.7l3.7-1.6c12.3-5.3 22.8-.6 28.6 12.9L310.2 350c1.4 3.2 5.1 4.6 8.3 3.3 3.2-1.4 4.7-5.1 3.3-8.3l-48.7-112.5c-2.2-5.2-3-10.8-2-15.4 1.1-5.4 4.5-9.3 9.9-11.7l3.7-1.6c5.3-2.3 11.1-2.3 16.4-.2 5.3 2.2 9.5 6.3 11.8 11.6l43.9 101.5c.7 1.6 1.9 2.7 3.5 3.4 1.6.6 3.3.6 4.8-.1 3.2-1.4 4.7-5.1 3.3-8.3l-32.8-75.9c-8.2-18.9 4.8-25.6 7.5-26.8 10.8-4.7 23.5.4 28.2 11.3l28.9 66.7c1.4 3.2 5.1 4.7 8.3 3.3 3.2-1.4 4.7-5.1 3.3-8.3l-19.4-44.8c-1.3-3-4.9-13.2 3.8-16.9l3.7-1.6c5.2-2.3 11.1-2.3 16.4 0 5.3 2.3 9.6 6.4 11.9 11.8L471.7 331c12.7 29.3 15.1 59.9 6.8 86.3-8.7 27.6-27.9 48.5-55.6 60.5L395 489.9c-38.9 16.9-80.1 8.4-113.3-23.3zm44.6-239.2l.3 2.1-.5-1.1.2-1zm-62.4-3.8l.3 2.7-.6-1.3.3-1.4zM31 217c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7zm0-66.3c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.1 2.8 5.7 6 5.7zM148 296h-40c-3.2 0-5.7 2.3-5.7 5.5s2.6 5.5 5.7 5.5h40c3.2 0 5.7-2.3 5.7-5.5s-2.6-5.5-5.7-5.5zM37 237.6c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-40zM31 84.4c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.1 2.8 5.7 6 5.7zM81.6 296H49.1c-1.7 0-3.4-.6-5-1.3-2.9-1.3-6.3-.1-7.5 2.8-1.3 2.9 0 6.3 2.9 7.5 3 1.3 6.3 2 9.6 2h32.5c3.2 0 5.7-2.3 5.7-5.5s-2.5-5.5-5.7-5.5zm60.6-281c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.6 6 5.7 6h40z"></path>
-            <path d="M323 122.4c-3.2 0-6 2.6-6 5.7v39.2c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-39.2c0-3.1-2.8-5.7-6-5.7zm6-60.6c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-40zM301.2 15h3.6c6.8 0 12.2 5.6 12.2 12.4v8.1c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-8.1C329 14.3 317.9 3 304.8 3h-3.6c-3.2 0-5.7 2.8-5.7 6s2.5 6 5.7 6zm-66.3 0h40c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.5 6 5.7 6zm-60.6 292h40c3.2 0 5.7-2.3 5.7-5.5s-2.6-5.5-5.7-5.5h-40c-3.2 0-5.7 2.3-5.7 5.5s2.5 5.5 5.7 5.5zm-5.8-292h40c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.6 6 5.7 6zM37.1 19.8c1.4 0 2.7-.6 3.8-1.5 2.3-2 5.2-3.2 8.2-3.2h26.8c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6H49.1c-5.9 0-11.5 2.5-15.9 6.5-2.3 2.1-2.5 5.9-.4 8.2 1.1 1.2 2.7 2 4.3 2z"></path>
+          <svg class="image-icon-drag" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+            <path
+              d="M383.6 229l-.5 1.5.7 1.7c-.2-1.1-.2-2.2-.2-3.2zm-119.7-5.4l-.3 1.4.6 1.3c-.2-.8-.3-1.8-.3-2.7zm62.4 3.8l-.2 1 .5 1.1-.3-2.1z">
+            </path>
+            <path
+              d="M483 326.2l-43.5-100.5c-3.6-8.4-10.3-14.9-18.7-18.4-8.5-3.6-17.8-3.5-26.1.1L391 209c-3.3 1.4-6.1 3.6-8.4 6.3-3.6-8.2-10.2-14.6-18.6-18-8.5-3.4-17.7-3.3-26.1.3-6.1 2.7-10.9 6.8-13.9 12-3.7-8-10.2-14.3-18.4-17.6-8.5-3.4-17.8-3.3-26.1.3l-3.7 1.6c-6.3 2.7-11.2 7.1-14.3 12.4l-20.3-46.9c-4.2-9.8-10.7-16.8-18.7-20.2-8.1-3.5-17.2-3.2-26.5.8l-3.7 1.6c-8 3.5-13.3 9.3-15.5 16.9-2.1 7.3-1 16.2 3.1 25.6l83.4 188.2-64.7-39.8c-11.2-6.8-25.7-4.7-34.4 5.1-11.3 12.5-10.3 31.9 2 43.3l55.8 51.5 50.8 43.4c17.6 16.7 38.2 28.1 59.6 32.9 7.7 1.7 15.5 2.5 23.2 2.5 14.9 0 29.7-3.1 44.2-9.4l27.9-12.1c31.2-13.5 52.8-37.1 62.6-68.4 9.2-29.2 6.6-63-7.3-95.1zM383.6 229c0 1 .1 2.1.2 3.1l-.7-1.7.5-1.4zM281.7 466.6c-.2-.2-.5-.5-.7-.6l-50.4-43.1-55.6-51.5c-7.3-6.7-7.9-18.2-1.2-25.6 4.7-5.3 12.5-6.4 18.5-2.6l65.6 40.2c4.7 2.9 10.4 2.4 14.5-1.3 4.1-3.6 5.3-9.2 3.2-14.2l-83.7-189c-3.2-7.4-3.9-13.4-2.1-18.1 1.7-4.3 5.2-6.5 7.9-7.7l3.7-1.6c12.3-5.3 22.8-.6 28.6 12.9L310.2 350c1.4 3.2 5.1 4.6 8.3 3.3 3.2-1.4 4.7-5.1 3.3-8.3l-48.7-112.5c-2.2-5.2-3-10.8-2-15.4 1.1-5.4 4.5-9.3 9.9-11.7l3.7-1.6c5.3-2.3 11.1-2.3 16.4-.2 5.3 2.2 9.5 6.3 11.8 11.6l43.9 101.5c.7 1.6 1.9 2.7 3.5 3.4 1.6.6 3.3.6 4.8-.1 3.2-1.4 4.7-5.1 3.3-8.3l-32.8-75.9c-8.2-18.9 4.8-25.6 7.5-26.8 10.8-4.7 23.5.4 28.2 11.3l28.9 66.7c1.4 3.2 5.1 4.7 8.3 3.3 3.2-1.4 4.7-5.1 3.3-8.3l-19.4-44.8c-1.3-3-4.9-13.2 3.8-16.9l3.7-1.6c5.2-2.3 11.1-2.3 16.4 0 5.3 2.3 9.6 6.4 11.9 11.8L471.7 331c12.7 29.3 15.1 59.9 6.8 86.3-8.7 27.6-27.9 48.5-55.6 60.5L395 489.9c-38.9 16.9-80.1 8.4-113.3-23.3zm44.6-239.2l.3 2.1-.5-1.1.2-1zm-62.4-3.8l.3 2.7-.6-1.3.3-1.4zM31 217c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7zm0-66.3c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.1 2.8 5.7 6 5.7zM148 296h-40c-3.2 0-5.7 2.3-5.7 5.5s2.6 5.5 5.7 5.5h40c3.2 0 5.7-2.3 5.7-5.5s-2.6-5.5-5.7-5.5zM37 237.6c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-40zM31 84.4c3.2 0 6-2.6 6-5.7v-40c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.1 2.8 5.7 6 5.7zM81.6 296H49.1c-1.7 0-3.4-.6-5-1.3-2.9-1.3-6.3-.1-7.5 2.8-1.3 2.9 0 6.3 2.9 7.5 3 1.3 6.3 2 9.6 2h32.5c3.2 0 5.7-2.3 5.7-5.5s-2.5-5.5-5.7-5.5zm60.6-281c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.6 6 5.7 6h40z">
+            </path>
+            <path
+              d="M323 122.4c-3.2 0-6 2.6-6 5.7v39.2c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-39.2c0-3.1-2.8-5.7-6-5.7zm6-60.6c0-3.2-2.8-5.7-6-5.7s-6 2.6-6 5.7v40c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-40zM301.2 15h3.6c6.8 0 12.2 5.6 12.2 12.4v8.1c0 3.2 2.8 5.7 6 5.7s6-2.6 6-5.7v-8.1C329 14.3 317.9 3 304.8 3h-3.6c-3.2 0-5.7 2.8-5.7 6s2.5 6 5.7 6zm-66.3 0h40c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.5 6 5.7 6zm-60.6 292h40c3.2 0 5.7-2.3 5.7-5.5s-2.6-5.5-5.7-5.5h-40c-3.2 0-5.7 2.3-5.7 5.5s2.5 5.5 5.7 5.5zm-5.8-292h40c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6h-40c-3.2 0-5.7 2.8-5.7 6s2.6 6 5.7 6zM37.1 19.8c1.4 0 2.7-.6 3.8-1.5 2.3-2 5.2-3.2 8.2-3.2h26.8c3.2 0 5.7-2.8 5.7-6s-2.6-6-5.7-6H49.1c-5.9 0-11.5 2.5-15.9 6.5-2.3 2.1-2.5 5.9-.4 8.2 1.1 1.2 2.7 2 4.3 2z">
+            </path>
           </svg>
         </div>
         <div class="text-center">
-          <label class="drag-text">{{dragText}}</label>
+          <label class="drag-text">{{ dragText }}</label>
           <br>
-          <a class="browse-text">{{browseText}}</a>
+          <a class="browse-text">{{ browseText }}</a>
         </div>
         <div class="image-input position-absolute full-width full-height">
-          <label
-            :for="idUpload"
-            class="full-width full-height cursor-pointer"
-          >
+          <label :for="idUpload" class="full-width full-height cursor-pointer">
           </label>
         </div>
       </div>
     </div>
 
-    <div
-      class="image-container position-relative text-center image-list"
-      v-else
-    >
-      <div
-        class="drag-upload-cover position-absolute"
-        v-if="isDragover"
-        @drop="onDrop"
-      >
+    <div class="image-container position-relative text-center image-list" v-else>
+      <div class="drag-upload-cover position-absolute" v-if="isDragover" @drop="onDrop">
         <div class="centered full-width text-center text-primary">
-          <svg
-            class="icon-drag-drop"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-          >
-            <path d="M444.5 15C407.7 15 378 44.8 378 81.5s29.8 66.5 66.5 66.5S511 118.2 511 81.5 481.2 15 444.5 15zm29.4 72.4h-23.5l.1 25.9c0 3.2-2.6 5.8-5.8 5.9-3.2 0-5.8-2.6-5.8-5.8l-.1-26h-23.6c-3.2 0-5.8-2.6-5.8-5.8s2.6-5.8 5.8-5.8h23.5l-.1-25.9c0-3.2 2.6-5.8 5.8-5.9 3.2 0 5.8 2.6 5.8 5.8l.1 26h23.6c3.3 0 5.8 2.6 5.8 5.8s-2.6 5.8-5.8 5.8zM199.3 191.3c21.5 0 38.9 17.6 38.9 39.3s-17.4 39.3-38.9 39.3-38.9-17.6-38.9-39.3c0-21.7 17.5-39.3 38.9-39.3zm185.4 201.3H86.3c-6.5 0-11.9-5.3-11.9-11.9v-32.4c0-2.5.7-4.8 2.1-6.9l41.3-58.4c3.7-5.2 10.8-6.5 16.1-3.1l56.4 36.8c4.5 3 10.3 2.5 14.4-1L313 220.1c5.1-4.5 13.1-3.8 17.2 1.7l61.5 79.7c1.6 2 2.5 4.6 2.5 7.2v74.4c0 5.2-4.3 9.5-9.5 9.5zm7.9 117.6h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0H98.4v-12h58.8v12h.1zm-78.5 0H57.7c-14.3 0-27.9-5.4-38.3-15.3l8.3-8.7c8.2 7.8 18.8 12 30.1 12h21.1l-.1 12zm333.6-.1l-.3-12c17.8-.4 33.4-11.5 39.8-28.2l11.2 4.3c-8.1 21.3-28 35.4-50.7 35.9zM6.8 477c-3.2-7.1-4.7-14.7-4.7-22.5v-38.2h12v38.2c0 6.1 1.3 12.1 3.7 17.6l-11 4.9zm459.9-24.1h-12v-58.8h12v58.8zM14.1 396.7h-12v-58.8h12v58.8zm452.6-22.3h-12v-58.8h12v58.8zM14.1 318.3h-12v-58.8h12v58.8zM466.7 296h-12v-58.8h12V296zM14.1 239.8h-12V181h12v58.8zm452.6-22.2h-12v-58.8h12v58.8zM14.1 161.4h-12v-58.8h12v58.8zm2.4-76.1L5.3 81.2C13 59.9 33.4 45.5 56.1 45.5h.2v12h-.2c-17.7 0-33.6 11.2-39.6 27.8zm353.6-27.8h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0H75.9v-12h58.8v12z"></path>
+          <svg class="icon-drag-drop" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+            <path
+              d="M444.5 15C407.7 15 378 44.8 378 81.5s29.8 66.5 66.5 66.5S511 118.2 511 81.5 481.2 15 444.5 15zm29.4 72.4h-23.5l.1 25.9c0 3.2-2.6 5.8-5.8 5.9-3.2 0-5.8-2.6-5.8-5.8l-.1-26h-23.6c-3.2 0-5.8-2.6-5.8-5.8s2.6-5.8 5.8-5.8h23.5l-.1-25.9c0-3.2 2.6-5.8 5.8-5.9 3.2 0 5.8 2.6 5.8 5.8l.1 26h23.6c3.3 0 5.8 2.6 5.8 5.8s-2.6 5.8-5.8 5.8zM199.3 191.3c21.5 0 38.9 17.6 38.9 39.3s-17.4 39.3-38.9 39.3-38.9-17.6-38.9-39.3c0-21.7 17.5-39.3 38.9-39.3zm185.4 201.3H86.3c-6.5 0-11.9-5.3-11.9-11.9v-32.4c0-2.5.7-4.8 2.1-6.9l41.3-58.4c3.7-5.2 10.8-6.5 16.1-3.1l56.4 36.8c4.5 3 10.3 2.5 14.4-1L313 220.1c5.1-4.5 13.1-3.8 17.2 1.7l61.5 79.7c1.6 2 2.5 4.6 2.5 7.2v74.4c0 5.2-4.3 9.5-9.5 9.5zm7.9 117.6h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0H98.4v-12h58.8v12h.1zm-78.5 0H57.7c-14.3 0-27.9-5.4-38.3-15.3l8.3-8.7c8.2 7.8 18.8 12 30.1 12h21.1l-.1 12zm333.6-.1l-.3-12c17.8-.4 33.4-11.5 39.8-28.2l11.2 4.3c-8.1 21.3-28 35.4-50.7 35.9zM6.8 477c-3.2-7.1-4.7-14.7-4.7-22.5v-38.2h12v38.2c0 6.1 1.3 12.1 3.7 17.6l-11 4.9zm459.9-24.1h-12v-58.8h12v58.8zM14.1 396.7h-12v-58.8h12v58.8zm452.6-22.3h-12v-58.8h12v58.8zM14.1 318.3h-12v-58.8h12v58.8zM466.7 296h-12v-58.8h12V296zM14.1 239.8h-12V181h12v58.8zm452.6-22.2h-12v-58.8h12v58.8zM14.1 161.4h-12v-58.8h12v58.8zm2.4-76.1L5.3 81.2C13 59.9 33.4 45.5 56.1 45.5h.2v12h-.2c-17.7 0-33.6 11.2-39.6 27.8zm353.6-27.8h-58.8v-12h58.8v12zm-78.5 0h-58.8v-12h58.8v12zm-78.4 0h-58.8v-12h58.8v12zm-78.5 0H75.9v-12h58.8v12z">
+            </path>
           </svg>
-          <h4 class="drop-text-here"><b>{{dropText}}</b></h4>
+          <h4 class="drop-text-here"><b>{{ dropText }}</b></h4>
         </div>
       </div>
-      <div
-        v-else
-        @dragover.prevent="onDragover"
-      >
-        <div
-          class="preview-image full-width position-relative cursor-pointer"
-          @click="openGallery(currentIndexImage)"
-        >
+      <div v-else @dragover.prevent="onDragover">
+        <div class="preview-image full-width position-relative cursor-pointer" @click="openGallery(currentIndexImage)">
           <div class="image-overlay position-relative full-width full-height"></div>
           <div class="image-overlay-details full-width">
-            <svg
-              class="icon-overlay"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 512 512"
-            >
-              <path d="M283.9 186.4h-64.6l-.4-71.1c-.1-8.8-7.2-15.9-16-15.9h-.1c-8.8.1-16 7.3-15.9 16.1l.4 70.9h-64.4c-8.8 0-16 7.2-16 16s7.2 16 16 16h64.6l.4 71.1c.1 8.8 7.2 15.9 16 15.9h.1c8.8-.1 16-7.3 15.9-16.1l-.4-70.9h64.4c8.8 0 16-7.2 16-16s-7.1-16-16-16z"></path>
-              <path d="M511.3 465.3L371.2 325.2c-1-1-2.6-1-3.6 0l-11.5 11.5c31.6-35.9 50.8-82.9 50.8-134.3C406.9 90.3 315.6-1 203.4-1 91.3-1 0 90.3 0 202.4s91.3 203.4 203.4 203.4c51.4 0 98.5-19.2 134.3-50.8l-11.5 11.5c-1 1-1 2.6 0 3.6l140.1 140.1c1 1 2.6 1 3.6 0l41.4-41.4c.9-.9.9-2.5 0-3.5zm-307.9-92.5C109.5 372.8 33 296.4 33 202.4S109.5 32.1 203.4 32.1s170.4 76.4 170.4 170.4-76.4 170.3-170.4 170.3z"></path>
+            <svg class="icon-overlay" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path
+                d="M283.9 186.4h-64.6l-.4-71.1c-.1-8.8-7.2-15.9-16-15.9h-.1c-8.8.1-16 7.3-15.9 16.1l.4 70.9h-64.4c-8.8 0-16 7.2-16 16s7.2 16 16 16h64.6l.4 71.1c.1 8.8 7.2 15.9 16 15.9h.1c8.8-.1 16-7.3 15.9-16.1l-.4-70.9h64.4c8.8 0 16-7.2 16-16s-7.1-16-16-16z">
+              </path>
+              <path
+                d="M511.3 465.3L371.2 325.2c-1-1-2.6-1-3.6 0l-11.5 11.5c31.6-35.9 50.8-82.9 50.8-134.3C406.9 90.3 315.6-1 203.4-1 91.3-1 0 90.3 0 202.4s91.3 203.4 203.4 203.4c51.4 0 98.5-19.2 134.3-50.8l-11.5 11.5c-1 1-1 2.6 0 3.6l140.1 140.1c1 1 2.6 1 3.6 0l41.4-41.4c.9-.9.9-2.5 0-3.5zm-307.9-92.5C109.5 372.8 33 296.4 33 202.4S109.5 32.1 203.4 32.1s170.4 76.4 170.4 170.4-76.4 170.3-170.4 170.3z">
+              </path>
             </svg>
           </div>
           <div class="show-image centered">
-            <img
-              class="show-img img-responsive"
-              :src="imagePreview"
-            >
+            <img class="show-img img-responsive" :src="imagePreview">
           </div>
         </div>
-        <div
-          class="image-bottom display-flex position-absolute full-width align-items-center justify-content-between"
-          :class="!showPrimary && 'justify-content-end'"
-        >
-          <div
-            class="image-bottom-left display-flex align-items-center"
-            v-if="showPrimary"
-          >
-            <div
-              class="display-flex align-items-center"
-              v-show="imageDefault"
-            >
+        <div class="image-bottom display-flex position-absolute full-width align-items-center justify-content-between"
+          :class="!showPrimary && 'justify-content-end'">
+          <div class="image-bottom-left display-flex align-items-center" v-if="showPrimary">
+            <div class="display-flex align-items-center" v-show="imageDefault">
               <span class="image-primary display-flex align-items-center">
-                <svg
-                  class="image-icon-primary"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 512 512"
-                >
-                  <circle
-                    fill="#10BC83"
-                    cx="256"
-                    cy="256"
-                    r="256"
-                  ></circle>
-                  <path
-                    fill="#FFF"
-                    d="M216.7 350.9h-.1c-5.1 0-9.9-2.1-13.4-5.7l-74.2-76c-7.4-7.5-7.2-19.5.4-26.8 7.5-7.4 19.5-7.2 26.8.4L217 305l139.7-138.5c7.5-7.4 19.5-7.4 26.8.1s7.4 19.5-.1 26.8l-153.2 152c-3.7 3.5-8.5 5.5-13.5 5.5z"
-                  ></path>
+                <svg class="image-icon-primary" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                  <circle fill="#10BC83" cx="256" cy="256" r="256"></circle>
+                  <path fill="#FFF"
+                    d="M216.7 350.9h-.1c-5.1 0-9.9-2.1-13.4-5.7l-74.2-76c-7.4-7.5-7.2-19.5.4-26.8 7.5-7.4 19.5-7.2 26.8.4L217 305l139.7-138.5c7.5-7.4 19.5-7.4 26.8.1s7.4 19.5-.1 26.8l-153.2 152c-3.7 3.5-8.5 5.5-13.5 5.5z">
+                  </path>
                 </svg>
-                {{primaryText}}
+                {{ primaryText }}
               </span>
-              <popper
-                trigger="click"
-                :options="{placement: 'top'}"
-              >
+              <popper trigger="click" :options="{ placement: 'top' }">
                 <div class="popper popper-custom">
-                  {{popupText}}
+                  {{ popupText }}
                 </div>
-                <i
-                  slot="reference"
-                  class="cursor-pointer display-flex align-items-center"
-                >
-                  <svg
-                    class="image-icon-info"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 512 512"
-                  >
-                    <path d="M256 32c30.3 0 59.6 5.9 87.2 17.6 26.7 11.3 50.6 27.4 71.2 48s36.7 44.5 48 71.2c11.7 27.6 17.6 56.9 17.6 87.2s-5.9 59.6-17.6 87.2c-11.3 26.7-27.4 50.6-48 71.2s-44.5 36.7-71.2 48C315.6 474.1 286.3 480 256 480s-59.6-5.9-87.2-17.6c-26.7-11.3-50.6-27.4-71.2-48s-36.7-44.5-48-71.2C37.9 315.6 32 286.3 32 256s5.9-59.6 17.6-87.2c11.3-26.7 27.4-50.6 48-71.2s44.5-36.7 71.2-48C196.4 37.9 225.7 32 256 32m0-32C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0z"></path>
-                    <path d="M304.2 352H296c-4.4 0-8-3.6-8-8v-94.8c0-15.3-11.5-28.1-26.7-29.8-2.5-.3-4.8-.5-6.7-.5-23.7 0-44.6 11.9-57 30.1l-.1.1v-.1c-1 2-1.7 5.3.7 6.5.6.3 1.2.5 1.8.5h16c4.4 0 8 3.6 8 8v80c0 4.4-3.6 8-8 8h-8.2c-8.7 0-15.8 7.1-15.8 15.8v.3c0 8.7 7.1 15.8 15.8 15.8h96.4c8.7 0 15.8-7.1 15.8-15.8v-.3c0-8.7-7.1-15.8-15.8-15.8zM256 128c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32z"></path>
+                <i slot="reference" class="cursor-pointer display-flex align-items-center">
+                  <svg class="image-icon-info" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <path
+                      d="M256 32c30.3 0 59.6 5.9 87.2 17.6 26.7 11.3 50.6 27.4 71.2 48s36.7 44.5 48 71.2c11.7 27.6 17.6 56.9 17.6 87.2s-5.9 59.6-17.6 87.2c-11.3 26.7-27.4 50.6-48 71.2s-44.5 36.7-71.2 48C315.6 474.1 286.3 480 256 480s-59.6-5.9-87.2-17.6c-26.7-11.3-50.6-27.4-71.2-48s-36.7-44.5-48-71.2C37.9 315.6 32 286.3 32 256s5.9-59.6 17.6-87.2c11.3-26.7 27.4-50.6 48-71.2s44.5-36.7 71.2-48C196.4 37.9 225.7 32 256 32m0-32C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0z">
+                    </path>
+                    <path
+                      d="M304.2 352H296c-4.4 0-8-3.6-8-8v-94.8c0-15.3-11.5-28.1-26.7-29.8-2.5-.3-4.8-.5-6.7-.5-23.7 0-44.6 11.9-57 30.1l-.1.1v-.1c-1 2-1.7 5.3.7 6.5.6.3 1.2.5 1.8.5h16c4.4 0 8 3.6 8 8v80c0 4.4-3.6 8-8 8h-8.2c-8.7 0-15.8 7.1-15.8 15.8v.3c0 8.7 7.1 15.8 15.8 15.8h96.4c8.7 0 15.8-7.1 15.8-15.8v-.3c0-8.7-7.1-15.8-15.8-15.8zM256 128c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32z">
+                    </path>
                   </svg>
                 </i>
               </popper>
             </div>
-            <a
-              class="text-small mark-text-primary cursor-pointer"
-              @click.prevent="markIsPrimary(currentIndexImage)"
-              v-show="!imageDefault"
-            >{{markIsPrimaryText}}</a>
+            <a class="text-small mark-text-primary cursor-pointer" @click.prevent="markIsPrimary(currentIndexImage)"
+              v-show="!imageDefault">{{ markIsPrimaryText }}</a>
           </div>
           <div class="display-flex">
-            <label
-              v-if="showEdit"
-              class="image-edit display-flex cursor-pointer"
-              :for="idEdit"
-            >
-              <svg
-                class="image-icon-edit"
-                xmlns="http://www.w3.org/2000/svg"
-                width="512"
-                height="512"
-                viewBox="0 0 512 512"
-              >
-                <path d="M469.56 42.433C420.927-6.199 382.331-.168 378.087.68l-4.8.96L36.895 338.001 0 512l173.985-36.894 336.431-336.399.941-4.86c.826-4.257 6.65-42.984-41.797-91.414zM41.944 470.057L64.3 364.617c12.448 3.347 31.968 11.255 50.51 29.794 18.96 18.963 27.84 39.986 31.875 53.436l-104.741 22.21zm132.504-41.134c-6.167-16.597-17.199-37.794-36.775-57.371C119 352.88 99.435 342.57 83.739 336.879l155.156-155.15 97.066-97.051c11.069 2.074 34.864 8.95 57.253 31.338 22.708 22.708 30.95 48.358 33.734 60.428l-96.685 96.663-155.815 155.816zm278.41-278.383c-6.167-16.6-17.196-37.8-36.781-57.384-18.669-18.667-38.228-28.977-53.92-34.668l26.118-26.113c8.785.484 30.373 4.87 58.423 32.918l.001.002c28.085 28.074 32.467 49.675 32.946 58.463l-26.787 26.782z"></path>
+            <label v-if="showEdit" class="image-edit display-flex cursor-pointer" :for="idEdit">
+              <svg class="image-icon-edit" xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+                viewBox="0 0 512 512">
+                <path
+                  d="M469.56 42.433C420.927-6.199 382.331-.168 378.087.68l-4.8.96L36.895 338.001 0 512l173.985-36.894 336.431-336.399.941-4.86c.826-4.257 6.65-42.984-41.797-91.414zM41.944 470.057L64.3 364.617c12.448 3.347 31.968 11.255 50.51 29.794 18.96 18.963 27.84 39.986 31.875 53.436l-104.741 22.21zm132.504-41.134c-6.167-16.597-17.199-37.794-36.775-57.371C119 352.88 99.435 342.57 83.739 336.879l155.156-155.15 97.066-97.051c11.069 2.074 34.864 8.95 57.253 31.338 22.708 22.708 30.95 48.358 33.734 60.428l-96.685 96.663-155.815 155.816zm278.41-278.383c-6.167-16.6-17.196-37.8-36.781-57.384-18.669-18.667-38.228-28.977-53.92-34.668l26.118-26.113c8.785.484 30.373 4.87 58.423 32.918l.001.002c28.085 28.074 32.467 49.675 32.946 58.463l-26.787 26.782z">
+                </path>
               </svg>
             </label>
-
-            <a
-              v-if="showDelete"
-              class="image-delete display-flex cursor-pointer"
-              @click.prevent="deleteImage(currentIndexImage)"
-            >
-              <svg
-                class="image-icon-delete"
-                xmlns="http://www.w3.org/2000/svg"
-                width="512"
-                height="512"
-                viewBox="0 0 512 512"
-              >
-                <path d="M448 64h-96V0H159.9l.066 64H32v32h32v416h384V96h32V64h-32zM192 32h128v32H192V32zm224 448H96V96h320v384zM192 160h32v256h-32V160zm96 0h32v256h-32V160z"></path>
+            <div
+              class="image-list-item position-relative cursor-pointer display-flex justify-content-center align-items-center margin-right-10"
+              v-if="(images.length < maxImage) && showAdd && !showImageList">
+              <svg class="icon add-image-svg" xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+                viewBox="0 0 512 512">
+                <path d="M511.5 227.5h-227V.5h-57v227H-.5v57h228v228h57v-228h227z"></path>
+              </svg>
+              <div class="input-add-image position-absolute full-width full-height ">
+                <label :for="idUpload" class="display-block full-width full-height cursor-pointer">
+                </label>
+              </div>
+            </div>
+            <div>
+              <input class="display-none" :id="idUpload" @change="uploadFieldChange" name="images" :multiple="multiple"
+                :accept="accept" type="file" :disabled="disabled">
+              <input class="display-none" :id="idEdit" @change="editFieldChange" name="image" :accept="accept"
+                type="file" :disabled="disabled">
+            </div>
+            <a v-if="showDelete" class="image-delete display-flex cursor-pointer"
+              @click.prevent="deleteImage(currentIndexImage)">
+              <svg class="image-icon-delete" xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+                viewBox="0 0 512 512">
+                <path
+                  d="M448 64h-96V0H159.9l.066 64H32v32h32v416h384V96h32V64h-32zM192 32h128v32H192V32zm224 448H96V96h320v384zM192 160h32v256h-32V160zm96 0h32v256h-32V160z">
+                </path>
               </svg>
             </a>
           </div>
@@ -202,77 +141,38 @@
       </div>
     </div>
 
-    <div
-      class="image-list-container display-flex flex-wrap"
-      v-if="images.length && multiple"
-    >
-      <div
-        class="image-list-item position-relative cursor-pointer"
-        :class="image.highlight && 'image-highlight'"
-        v-for="(image, index) in images"
-        :key="index"
-        @click="changeHighlight(index)"
-      >
-        <div class="centered">
-          <img
-            class="show-img img-responsive"
-            :src="image.path"
-          >
+    <div v-if="showImageList">
+      <div class="image-list-container display-flex flex-wrap" v-if="images.length && multiple">
+        <div class="image-list-item position-relative cursor-pointer" :class="image.highlight && 'image-highlight'"
+          v-for="(image, index) in images" :key="index" @click="changeHighlight(index)">
+          <div class="centered">
+            <img class="show-img img-responsive" :src="image.path">
+          </div>
+        </div>
+        <div
+          class="image-list-item position-relative cursor-pointer display-flex justify-content-center align-items-center"
+          v-if="(images.length < maxImage) && showAdd">
+          <svg class="icon add-image-svg" xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+            viewBox="0 0 512 512">
+            <path d="M511.5 227.5h-227V.5h-57v227H-.5v57h228v228h57v-228h227z"></path>
+          </svg>
+          <div class="input-add-image position-absolute full-width full-height">
+            <label :for="idUpload" class="display-block full-width full-height cursor-pointer">
+            </label>
+          </div>
         </div>
       </div>
-      <div
-        class="image-list-item position-relative cursor-pointer display-flex justify-content-center align-items-center"
-        v-if="(images.length < maxImage) && showAdd"
-      >
-        <svg
-          class="icon add-image-svg"
-          xmlns="http://www.w3.org/2000/svg"
-          width="512"
-          height="512"
-          viewBox="0 0 512 512"
-        >
-          <path d="M511.5 227.5h-227V.5h-57v227H-.5v57h228v228h57v-228h227z"></path>
-        </svg>
-        <div class="input-add-image position-absolute full-width full-height">
-          <label
-            :for="idUpload"
-            class="display-block full-width full-height cursor-pointer"
-          >
-          </label>
-        </div>
+      <div>
+        <input class="display-none" :id="idUpload" @change="uploadFieldChange" name="images" :multiple="multiple"
+          :accept="accept" type="file" :disabled="disabled">
+        <input class="display-none" :id="idEdit" @change="editFieldChange" name="image" :accept="accept" type="file"
+          :disabled="disabled">
       </div>
-    </div>
-    <div>
-      <input
-        class="display-none"
-        :id="idUpload"
-        @change="uploadFieldChange"
-        name="images"
-        :multiple="multiple"
-        :accept="accept"
-        type="file"
-        :disabled="disabled"
-      >
-      <input
-        class="display-none"
-        :id="idEdit"
-        @change="editFieldChange"
-        name="image"
-        :accept="accept"
-        type="file"
-        :disabled="disabled"
-      >
-    </div>
 
-    <vue-image-lightbox-carousel
-      ref="lightbox"
-      :show="showLightbox"
-      @close="showLightbox = false"
-      :images="images"
-      @change="changeHighlight"
-      :showCaption="false"
-    >
-    </vue-image-lightbox-carousel>
+      <vue-image-lightbox-carousel ref="lightbox" :show="showLightbox" @close="showLightbox = false" :images="images"
+        @change="changeHighlight" :showCaption="false">
+      </vue-image-lightbox-carousel>
+    </div>
   </div>
 </template>
 
@@ -356,8 +256,12 @@ export default {
       type: Boolean,
       default: false
     },
+    showImageList: {
+      type: Boolean,
+      default: false
+    }
   },
-  data () {
+  data() {
     return {
       currentIndexImage: 0,
       images: [],
@@ -371,7 +275,7 @@ export default {
     VueImageLightboxCarousel
   },
   computed: {
-    imagePreview () {
+    imagePreview() {
       let index = findIndex(this.images, { highlight: 1 })
       if (index > -1) {
         return this.images[index].path
@@ -379,18 +283,18 @@ export default {
         return this.images.length ? this.images[0].path : ''
       }
     },
-    imageDefault () {
+    imageDefault() {
       if (this.images[this.currentIndexImage]) {
         return this.images[this.currentIndexImage].default
       }
     }
   },
   methods: {
-    preventEvent (e) {
+    preventEvent(e) {
       e.preventDefault()
       e.stopPropagation()
     },
-    onDrop (e) {
+    onDrop(e) {
       this.isDragover = false
       e.stopPropagation()
       e.preventDefault()
@@ -411,10 +315,10 @@ export default {
         document.getElementById(this.idUpload).value = []
       }
     },
-    onDragover () {
+    onDragover() {
       this.isDragover = true
     },
-    createImage (file) {
+    createImage(file) {
       if (this.disabled) return
       let reader = new FileReader()
       let formData = new FormData()
@@ -433,7 +337,7 @@ export default {
       }
       reader.readAsDataURL(file)
     },
-    editImage (file) {
+    editImage(file) {
       if (this.disabled) return
       let reader = new FileReader()
       let formData = new FormData()
@@ -450,7 +354,7 @@ export default {
       reader.readAsDataURL(file)
       this.$emit('edit-image', formData, this.currentIndexImage, this.images)
     },
-    uploadFieldChange (e) {
+    uploadFieldChange(e) {
       let files = e.target.files || e.dataTransfer.files
       if (!files.length) {
         return false
@@ -465,7 +369,7 @@ export default {
         document.getElementById(this.idUpload).value = []
       }
     },
-    editFieldChange (e) {
+    editFieldChange(e) {
       let files = e.target.files || e.dataTransfer.files
       if (!files.length) {
         return false
@@ -480,7 +384,7 @@ export default {
         document.getElementById(this.idEdit).value = ''
       }
     },
-    changeHighlight (currentIndex) {
+    changeHighlight(currentIndex) {
       this.currentIndexImage = currentIndex
       let arr = this.images
       this.images = []
@@ -494,7 +398,7 @@ export default {
       })
       this.images = arr
     },
-    markIsPrimary (currentIndex) {
+    markIsPrimary(currentIndex) {
       this.images.map((item, index) => {
         if (currentIndex === index) {
           item.highlight = 1
@@ -509,7 +413,7 @@ export default {
       this.images = orderBy(this.images, 'default', 'desc')
       this.$emit('mark-is-primary', currentIndex, this.images)
     },
-    deleteImage (currentIndex) {
+    deleteImage(currentIndex) {
       this.$emit('before-remove', currentIndex, () => {
         if (this.images[currentIndex].default === 1) {
           this.images[0].default = 1
@@ -521,18 +425,18 @@ export default {
         }
       }, this.images)
     },
-    openGallery (index) {
+    openGallery(index) {
       this.showLightbox = true
       this.$refs.lightbox.showImage(index)
     },
-    onOpenedLightBox (value) {
+    onOpenedLightBox(value) {
       if (value) {
         this.showLightbox = true
       } else {
         this.showLightbox = false
       }
     },
-    isValidNumberOfImages (amount) {
+    isValidNumberOfImages(amount) {
       if (amount > this.maxImage) {
         this.$emit('limit-exceeded', amount)
         return false
@@ -549,14 +453,14 @@ export default {
       deep: true
     }
   },
-  mounted () {
+  mounted() {
     document.body.addEventListener('dragleave', (event) => {
       event.stopPropagation()
       event.preventDefault()
       this.isDragover = false
     })
   },
-  created () {
+  created() {
     this.images = []
     this.images = cloneDeep(this.dataImages)
   }
@@ -567,48 +471,67 @@ export default {
 .text-small {
   font-size: 11px;
 }
+
+.margin-right-10 {
+  margin-right: 10px;
+}
+
 .position-relative {
   position: relative;
 }
+
 .position-absolute {
   position: absolute;
 }
+
 .text-center {
   text-align: center;
 }
+
 .text-primary {
   color: #2fa3e6;
 }
+
 .display-flex {
   display: flex;
 }
+
 .flex-column {
   flex-direction: column;
 }
+
 .flex-wrap {
   flex-wrap: wrap;
 }
+
 .justify-content-center {
   justify-content: center;
 }
+
 .justify-content-between {
   justify-content: space-between;
 }
+
 .justify-content-end {
   justify-content: flex-end;
 }
+
 .align-items-center {
   align-items: center;
 }
+
 .full-width {
   width: 100%;
 }
+
 .full-height {
   height: 100%;
 }
+
 .cursor-pointer {
   cursor: pointer;
 }
+
 .centered {
   left: 50%;
   transform: translate(-50%, -50%);
@@ -616,6 +539,7 @@ export default {
   position: absolute;
   display: block;
 }
+
 .image-container {
   width: 190px;
   height: 180px;
@@ -623,26 +547,31 @@ export default {
   border-radius: 4px;
   background-color: #fff;
 }
+
 .image-center {
   width: 100%;
   height: 100%;
 }
+
 .image-icon-drag {
   fill: #c9c8c8;
   height: 50px;
   width: 50px;
 }
+
 .drag-text {
   padding-top: 5px;
   color: #777;
   font-weight: 400;
   line-height: 1.5;
 }
+
 .browse-text {
   font-size: 86%;
   color: #206ec5;
   text-decoration: none;
 }
+
 .image-input {
   overflow: hidden;
   opacity: 0;
@@ -650,9 +579,11 @@ export default {
   left: 0;
   bottom: 0;
 }
+
 .image-input label {
   display: block;
 }
+
 .drag-upload-cover {
   top: 0;
   left: 0;
@@ -664,19 +595,23 @@ export default {
   margin: 5px;
   border: 2px dashed #268ddd;
 }
+
 .drag-upload-cover {
   font-weight: 400;
   font-size: 20px;
 }
+
 .icon-drag-drop {
   height: 50px;
   width: 50px;
   fill: #2fa3e6;
 }
+
 .drop-text-here {
   margin: 0;
   line-height: 1.5;
 }
+
 .display-none {
   display: none;
 }
@@ -685,12 +620,14 @@ export default {
 .image-list {
   border: 1px solid #d6d6d6;
 }
+
 .preview-image {
   height: 140px;
   padding: 5px;
   border-radius: 15px;
   box-sizing: border-box;
 }
+
 .image-overlay {
   background: rgba(0, 0, 0, 0.7);
   z-index: 10;
@@ -698,6 +635,7 @@ export default {
   opacity: 0;
   transition: all 0.3s ease-in-out 0s;
 }
+
 .image-overlay-details {
   position: absolute;
   z-index: 11;
@@ -705,26 +643,31 @@ export default {
   transform: translate(0, -50%);
   top: 50%;
 }
+
 .icon-overlay {
   width: 40px;
   height: 40px;
   fill: #fff;
 }
+
 .preview-image:hover .image-overlay,
 .preview-image:hover .image-overlay-details {
   opacity: 1;
 }
+
 .img-responsive {
   display: block;
   max-width: 100%;
   height: auto;
 }
+
 .show-img {
   max-height: 100px;
   max-width: 140px;
   display: block;
   vertical-align: middle;
 }
+
 /*image bottom*/
 .image-bottom {
   bottom: 0;
@@ -733,6 +676,7 @@ export default {
   padding: 5px 10px;
   box-sizing: border-box;
 }
+
 .image-primary {
   border-radius: 4px;
   background-color: #e3edf7;
@@ -740,51 +684,62 @@ export default {
   font-size: 11px;
   margin-right: 5px;
 }
+
 .image-icon-primary {
   width: 10px;
   height: 10px;
   margin-right: 2px;
 }
+
 .image-icon-delete {
   height: 14px;
   width: 14px;
   fill: #222;
 }
+
 .image-edit {
   margin-right: 10px;
 }
+
 .image-icon-edit {
   height: 14px;
   width: 14px;
   fill: #222;
 }
+
 .image-list-container {
   max-width: 190px;
   min-height: 50px;
   margin-top: 10px;
 }
+
 .image-list-container .image-list-item {
   height: 32px;
   width: 32px;
   border-radius: 4px;
   border: 1px solid #d6d6d6;
 }
+
 .image-list-container .image-list-item:not(:last-child) {
   margin-right: 5px;
   margin-bottom: 5px;
 }
+
 .image-list-container .image-list-item .show-img {
   max-width: 25px;
   max-height: 17px;
 }
+
 .image-list-container .image-highlight {
   border: 1px solid #2fa3e7;
 }
+
 .add-image-svg {
   width: 12px;
   height: 12px;
   fill: #222;
 }
+
 .input-add-image {
   overflow: hidden;
   opacity: 0;
@@ -793,17 +748,21 @@ export default {
   bottom: 0;
   z-index: 11;
 }
+
 .input-add-image label {
   display: block;
 }
+
 .image-icon-info {
   width: 14px;
   height: 14px;
   fill: #222;
 }
+
 .mark-text-primary {
   color: #034694;
 }
+
 .popper-custom {
   background: #000;
   padding: 10px;

--- a/src/components/VueUploadMultipleImage.vue
+++ b/src/components/VueUploadMultipleImage.vue
@@ -258,7 +258,7 @@ export default {
     },
     showImageList: {
       type: Boolean,
-      default: false
+      default: true
     }
   },
   data() {


### PR DESCRIPTION
- Moved `vue-image-lightbox-carousel` outside the `v-if="!showImageReorder"` block so it's always mounted in the DOM, since when `showImageReorder` is `true` (the default) the lightbox never rendered and `this.$refs.lightbox` was `undefined` on click.
- Wrapped `this.$refs.lightbox.showImage(index)` in `$nextTick` to ensure the ref is available before calling it.